### PR TITLE
Search pattern highlighting

### DIFF
--- a/include/parameter_tree.hpp
+++ b/include/parameter_tree.hpp
@@ -10,12 +10,15 @@
 #define RIG_RECONFIGURE_PARAMETER_TREE_HPP
 
 #include <memory>
+#include <optional>
 #include "responses.hpp"
 
 struct ParameterGroup {
     explicit ParameterGroup(std::string prefix = "") : prefix(std::move(prefix)) {};
 
     std::string prefix;
+    std::optional<std::size_t> prefixSearchPatternStart;
+    std::optional<std::size_t> prefixSearchPatternEnd;
 
     std::vector<ROSParameter> parameters;
     std::vector<std::shared_ptr<ParameterGroup>> subgroups;

--- a/include/ros_parameter.hpp
+++ b/include/ros_parameter.hpp
@@ -11,13 +11,22 @@
 
 #include <string>
 #include <variant>
+#include <optional>
 
 struct ROSParameter {
-    ROSParameter(std::string name, std::variant<bool, int, double, std::string> value) : name(std::move(name)), value(std::move(value)) {};
+    ROSParameter(std::string name, std::variant<bool, int, double, std::string> value,
+                 std::optional<std::size_t> searchPatternStart = std::nullopt,
+                 std::optional<std::size_t> searchPatternEnd = std::nullopt) : name(std::move(name)), value(std::move(value)),
+        searchPatternStart(searchPatternStart), searchPatternEnd(searchPatternEnd) {};
 
     std::string name;
     // TODO: add arrays
     std::variant<bool, int, double, std::string> value;
+
+    // in case this parameter is part of a filtered parameter tree the following two members store the intermediate
+    // information where in the name the applied search pattern is located
+    std::optional<std::size_t> searchPatternStart;
+    std::optional<std::size_t> searchPatternEnd;
 };
 
 #endif // RIG_RECONFIGURE_ROS_PARAMETER_HPP

--- a/src/parameter_tree.cpp
+++ b/src/parameter_tree.cpp
@@ -90,8 +90,20 @@ void ParameterTree::filter(const std::shared_ptr<ParameterGroup> &destinationNod
     // filter parameters
     for (const auto &parameter : sourceNode->parameters) {
         auto fullParameterName = prefix + '/' + toUpperCase(parameter.name);
-        if (fullParameterName.find(filterString) != std::string::npos) {
-            destinationNode->parameters.push_back(parameter);
+        const auto pos = fullParameterName.find(filterString);
+        if (pos != std::string::npos) {
+            // we need to realign the position of the pattern because the parameter stores only the name (without
+            // the prefix) + the pattern could be contained in the prefix and the parameter
+            auto searchPatternPos = toUpperCase(parameter.name).find(filterString);
+
+            if (searchPatternPos != std::string::npos) {
+                destinationNode->parameters.push_back(parameter);
+                destinationNode->parameters.back().searchPatternStart = searchPatternPos;
+                destinationNode->parameters.back().searchPatternEnd = searchPatternPos + filterString.length();
+            } else {
+                // search pattern was found in the prefix --> nothing to highlight within the parameter name
+                destinationNode->parameters.push_back(parameter);
+            }
         }
     }
 

--- a/src/parameter_tree.cpp
+++ b/src/parameter_tree.cpp
@@ -111,6 +111,13 @@ void ParameterTree::filter(const std::shared_ptr<ParameterGroup> &destinationNod
     for (const auto &subgroup : sourceNode->subgroups) {
         auto newPrefix = prefix + '/' + toUpperCase(subgroup->prefix);
         destinationNode->subgroups.push_back(std::make_shared<ParameterGroup>(subgroup->prefix));
+
+        auto searchPatternPos = toUpperCase(subgroup->prefix).find(filterString);
+        if (searchPatternPos != std::string::npos) {
+            destinationNode->subgroups.back()->prefixSearchPatternStart = searchPatternPos;
+            destinationNode->subgroups.back()->prefixSearchPatternEnd = searchPatternPos + filterString.length();
+        }
+
         filter(destinationNode->subgroups.back(), subgroup, filterString, newPrefix);
     }
 }

--- a/src/rig_reconfigure.cpp
+++ b/src/rig_reconfigure.cpp
@@ -33,7 +33,6 @@ static void glfw_error_callback(int error, const char *description) {
 
 void visualizeParameters(ServiceWrapper &serviceWrapper, const std::shared_ptr<ParameterGroup> &parameterNode,
                          std::size_t maxParamLength, const std::string &filterString, const std::string &prefix = "");
-std::size_t findCaseInsensitive(const std::string &string, const std::string &pattern);
 void highlightedText(const std::string &text, std::size_t start, std::size_t end,
                      const ImVec4 highlightColor = FILTER_HIGHLIGHTING_COLOR);
 
@@ -407,15 +406,6 @@ void visualizeParameters(ServiceWrapper &serviceWrapper, const std::shared_ptr<P
             }
         }
     }
-}
-
-// based on the following stack overflow answer: https://stackoverflow.com/a/19839371
-std::size_t findCaseInsensitive(const std::string &string, const std::string &pattern) {
-    auto it = std::search(string.begin(), string.end(), pattern.begin(), pattern.end(),
-            [](unsigned char ch1, unsigned char ch2) { return std::toupper(ch1) == std::toupper(ch2); }
-    );
-
-    return (it != string.end()) ? std::distance(string.begin(), it) : std::string::npos;
 }
 
 void highlightedText(const std::string &text, std::size_t start, std::size_t end,

--- a/src/rig_reconfigure.cpp
+++ b/src/rig_reconfigure.cpp
@@ -39,8 +39,6 @@ void print_error_and_fail(const std::string &error) {
 void visualizeParameters(ServiceWrapper &serviceWrapper, const std::shared_ptr<ParameterGroup> &parameterNode,
                          std::size_t maxParamLength, const std::string &filterString, const std::string &prefix = "");
 std::size_t findCaseInsensitive(const std::string &string, const std::string &pattern);
-void highlightedText(const std::string &text, const std::string &pattern = "",
-                     const ImVec4 highlightColor = FILTER_HIGHLIGHTING_COLOR);
 void highlightedText(const std::string &text, std::size_t start, std::size_t end,
                      const ImVec4 highlightColor = FILTER_HIGHLIGHTING_COLOR);
 
@@ -400,7 +398,12 @@ void visualizeParameters(ServiceWrapper &serviceWrapper, const std::shared_ptr<P
         for (const auto &subgroup : parameterNode->subgroups) {
             bool open = ImGui::TreeNode(("##" + subgroup->prefix).c_str());
             ImGui::SameLine();
-            highlightedText(subgroup->prefix, filterString);
+            if (subgroup->prefixSearchPatternStart.has_value() && subgroup->prefixSearchPatternEnd.has_value()) {
+                highlightedText(subgroup->prefix, subgroup->prefixSearchPatternStart.value(),
+                                subgroup->prefixSearchPatternEnd.value());
+            } else {
+                ImGui::Text("%s", subgroup->prefix.c_str());
+            }
 
             if (open) {
                 visualizeParameters(serviceWrapper, subgroup, maxParamLength, filterString,
@@ -418,26 +421,6 @@ std::size_t findCaseInsensitive(const std::string &string, const std::string &pa
     );
 
     return (it != string.end()) ? std::distance(string.begin(), it) : std::string::npos;
-}
-
-void highlightedText(const std::string &text, const std::string &pattern,
-                     const ImVec4 highlightColor) {
-
-    if (pattern.empty()) {
-        ImGui::Text("%s", text.c_str());
-        return;
-    }
-
-    auto startPos = findCaseInsensitive(text, pattern);
-
-    if (startPos == std::string::npos) {
-        ImGui::Text("%s", text.c_str());
-        return;
-    }
-
-    const auto endPos = startPos + pattern.length();
-
-    highlightedText(text, startPos, endPos, highlightColor);
 }
 
 void highlightedText(const std::string &text, std::size_t start, std::size_t end,

--- a/src/rig_reconfigure.cpp
+++ b/src/rig_reconfigure.cpp
@@ -31,11 +31,6 @@ static void glfw_error_callback(int error, const char *description) {
     fprintf(stderr, "Glfw Error %d: %s\n", error, description);
 }
 
-void print_error_and_fail(const std::string &error) {
-    std::cerr << error << std::endl;
-    std::exit(1);
-}
-
 void visualizeParameters(ServiceWrapper &serviceWrapper, const std::shared_ptr<ParameterGroup> &parameterNode,
                          std::size_t maxParamLength, const std::string &filterString, const std::string &prefix = "");
 std::size_t findCaseInsensitive(const std::string &string, const std::string &pattern);

--- a/src/rig_reconfigure.cpp
+++ b/src/rig_reconfigure.cpp
@@ -34,7 +34,7 @@ static void glfw_error_callback(int error, const char *description) {
 void visualizeParameters(ServiceWrapper &serviceWrapper, const std::shared_ptr<ParameterGroup> &parameterNode,
                          std::size_t maxParamLength, const std::string &filterString, const std::string &prefix = "");
 void highlightedText(const std::string &text, std::size_t start, std::size_t end,
-                     const ImVec4 highlightColor = FILTER_HIGHLIGHTING_COLOR);
+                     const ImVec4 &highlightColor = FILTER_HIGHLIGHTING_COLOR);
 
 int main(int argc, char *argv[]) {
     rclcpp::init(argc, argv);
@@ -409,7 +409,7 @@ void visualizeParameters(ServiceWrapper &serviceWrapper, const std::shared_ptr<P
 }
 
 void highlightedText(const std::string &text, std::size_t start, std::size_t end,
-                     const ImVec4 highlightColor) {
+                     const ImVec4 &highlightColor) {
     if (start == std::string::npos) {
         ImGui::Text("%s", text.c_str());
         return;

--- a/src/rig_reconfigure.cpp
+++ b/src/rig_reconfigure.cpp
@@ -21,6 +21,7 @@
 
 constexpr auto INPUT_TEXT_FIELD_WIDTH = 100;
 constexpr auto FILTER_INPUT_TEXT_FIELD_WIDTH = 250;
+constexpr auto FILTER_HIGHLIGHTING_COLOR = ImVec4(1, 0, 0, 1);
 
 enum class StatusTextType {
     NONE, NO_NODES_AVAILABLE, PARAMETER_CHANGED, SERVICE_TIMEOUT
@@ -36,7 +37,10 @@ void print_error_and_fail(const std::string &error) {
 }
 
 void visualizeParameters(ServiceWrapper &serviceWrapper, const std::shared_ptr<ParameterGroup> &parameterNode,
-                         std::size_t maxParamLength, bool filteredTree, const std::string &prefix = "");
+                         std::size_t maxParamLength, const std::string &filterString, const std::string &prefix = "");
+std::size_t findCaseInsensitive(const std::string &string, const std::string &pattern);
+void highlightedText(const std::string &text, const std::string &pattern = "",
+                     const ImVec4 highlightColor = FILTER_HIGHLIGHTING_COLOR);
 
 int main(int argc, char *argv[]) {
     rclcpp::init(argc, argv);
@@ -291,7 +295,7 @@ int main(int argc, char *argv[]) {
             ImGui::Dummy(ImVec2(0.0f, 10.0f));
 
             visualizeParameters(serviceWrapper, filteredParameterTree.getRoot(), filteredParameterTree.getMaxParamNameLength(),
-                                !currentFilterString.empty());
+                                currentFilterString);
 
             if (statusType == StatusTextType::NO_NODES_AVAILABLE) {
                 status.clear();
@@ -340,9 +344,9 @@ int main(int argc, char *argv[]) {
 }
 
 void visualizeParameters(ServiceWrapper &serviceWrapper, const std::shared_ptr<ParameterGroup> &parameterNode,
-                         std::size_t maxParamLength, const bool filteredTree, const std::string &prefix) {
+                         std::size_t maxParamLength, const std::string &filterString, const std::string &prefix) {
     if (parameterNode == nullptr || (parameterNode->parameters.empty() && parameterNode->subgroups.empty())) {
-        if (filteredTree) {
+        if (!filterString.empty()) {
             ImGui::Text("This node doesn't seem to have any parameters\nmatching the filter!");
         } else {
             ImGui::Text("This node doesn't seem to have any parameters!");
@@ -353,17 +357,21 @@ void visualizeParameters(ServiceWrapper &serviceWrapper, const std::shared_ptr<P
 
     for (auto &[name, value] : parameterNode->parameters) {
         std::string identifier = "##" + name;
-        std::string paddedName;
 
         // simple 'space' padding to avoid the need for a more complex layout with columns (the latter is still desired :D)
+        std::string padding;
         if (name.length() < maxParamLength) {
-            paddedName = name + std::string(maxParamLength - name.length(), ' ');
-        } else {
-            paddedName = name;
+            padding = std::string(maxParamLength - name.length(), ' ');
         }
 
         ImGui::AlignTextToFramePadding();
-        ImGui::Text("%s", paddedName.c_str());
+
+        highlightedText(name, filterString);
+
+        ImGui::SameLine(0, 0);
+        ImGui::Text("%s", padding.c_str());
+
+
         ImGui::SameLine();
         ImGui::PushItemWidth(INPUT_TEXT_FIELD_WIDTH);
         std::string prefixWithName = prefix + '/' + name;
@@ -385,11 +393,53 @@ void visualizeParameters(ServiceWrapper &serviceWrapper, const std::shared_ptr<P
 
     if (!parameterNode->subgroups.empty()) {
         for (const auto &subgroup : parameterNode->subgroups) {
-            if (ImGui::TreeNode(subgroup->prefix.c_str())) {
-                visualizeParameters(serviceWrapper, subgroup, maxParamLength, filteredTree,
-                                    prefix + '/' +  subgroup->prefix);
+            bool open = ImGui::TreeNode(("##" + subgroup->prefix).c_str());
+            ImGui::SameLine();
+            highlightedText(subgroup->prefix, filterString);
+
+            if (open) {
+                visualizeParameters(serviceWrapper, subgroup, maxParamLength, filterString,
+                                    prefix + '/' +  subgroup->prefix.c_str());
                 ImGui::TreePop();
             }
         }
+    }
+}
+
+// based on the following stack overflow answer: https://stackoverflow.com/a/19839371
+std::size_t findCaseInsensitive(const std::string &string, const std::string &pattern) {
+    auto it = std::search(string.begin(), string.end(), pattern.begin(), pattern.end(),
+            [](unsigned char ch1, unsigned char ch2) { return std::toupper(ch1) == std::toupper(ch2); }
+    );
+
+    return (it != string.end()) ? std::distance(string.begin(), it) : std::string::npos;
+}
+
+void highlightedText(const std::string &text, const std::string &pattern,
+                     const ImVec4 highlightColor) {
+
+    if (pattern.empty()) {
+        ImGui::Text("%s", text.c_str());
+        return;
+    }
+
+    auto startPos = findCaseInsensitive(text, pattern);
+
+    if (startPos == std::string::npos) {
+        ImGui::Text("%s", text.c_str());
+        return;
+    }
+
+    const auto endPos = startPos + pattern.length();
+    if (startPos > 0) {
+        ImGui::Text("%s", text.substr(0, startPos).c_str());
+        ImGui::SameLine(0, 0);
+    }
+
+    ImGui::TextColored(FILTER_HIGHLIGHTING_COLOR, "%s", text.substr(startPos, pattern.length()).c_str());
+
+    if (endPos < text.length() - 1) {
+        ImGui::SameLine(0, 0);
+        ImGui::Text("%s", text.substr(endPos).c_str());
     }
 }


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/45536968/219873157-51d79336-4837-429e-8d5f-d30017c4b22e.png)

Known issue: 
Search patterns can be of the form `prefix/startOfParamName` and will be matched correctly, however, the highlighting is currently limited to a single prefix / the parameter name. This is a won't fix since the use case seems to be rather uncommon.