### PR TITLE
Add missing buildtool_depends on git

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,6 +9,7 @@
     <license>MIT</license>
 
     <buildtool_depend>ament_cmake</buildtool_depend>
+    <buildtool_depend>git</buildtool_depend>
     <depend>libglfw3-dev</depend>
     <depend>rclcpp</depend>
 


### PR DESCRIPTION
This dependency is needed for a call to `FetchContent_Declare`.

Should resolve RHEL build failures on the buildfarm: https://build.ros2.org/view/Rbin_rhel_el964/job/Rbin_rhel_el964__rig_reconfigure__rhel_9_x86_64__binary/