### PR TITLE
Accept more separators

### DIFF
--- a/include/parameter_tree.hpp
+++ b/include/parameter_tree.hpp
@@ -40,7 +40,7 @@ struct TreeElement {
     ROSParameterVariant value;
 
     // in case this parameter is part of a filtered parameter tree the following two members store the intermediate
-    // information where in the name the applied search pattern is located
+    // information where in the name (not the fullPath!) the applied search pattern is located
     std::optional<std::size_t> searchPatternStart;
     std::optional<std::size_t> searchPatternEnd;
 };
@@ -75,8 +75,7 @@ class ParameterTree {
 
     void filter(const std::shared_ptr<ParameterGroup> &destinationNode,
                 const std::shared_ptr<ParameterGroup> &sourceNode,
-                const std::string &filterString,
-                const std::string &prefix) const;
+                const std::string &filterString) const;
 
     std::shared_ptr<ParameterGroup> root = nullptr;
 

--- a/include/parameter_tree.hpp
+++ b/include/parameter_tree.hpp
@@ -11,7 +11,39 @@
 
 #include <memory>
 #include <optional>
+#include <utility>
 #include "responses.hpp"
+
+/**
+ * Extension of the ROS parameter struct, adding information which is relevant
+ * for the parameter tree.
+ */
+struct TreeElement {
+    TreeElement(const ROSParameter &parameter, std::string fullParameterPath,
+                std::optional<std::size_t> patternStart = std::nullopt,
+                std::optional<std::size_t> patternEnd = std::nullopt) :
+        name(parameter.name), fullPath(std::move(fullParameterPath)), value(parameter.value),
+        searchPatternStart(patternStart), searchPatternEnd(patternEnd) {};
+
+    TreeElement(std::string name, std::string fullParameterPath, ROSParameterVariant value,
+                std::optional<std::size_t> patternStart = std::nullopt,
+                std::optional<std::size_t> patternEnd = std::nullopt) :
+        name(std::move(name)), fullPath(std::move(fullParameterPath)), value(std::move(value)),
+        searchPatternStart(patternStart), searchPatternEnd(patternEnd) {};
+
+    std::string name; // parameter name without prefixes
+
+    // in addition to the name we store the full path of the parameter in the leaf nodes of the tree in order to be
+    // able to support the mixing of different separators
+    std::string fullPath;
+
+    ROSParameterVariant value;
+
+    // in case this parameter is part of a filtered parameter tree the following two members store the intermediate
+    // information where in the name the applied search pattern is located
+    std::optional<std::size_t> searchPatternStart;
+    std::optional<std::size_t> searchPatternEnd;
+};
 
 struct ParameterGroup {
     explicit ParameterGroup(std::string prefix = "") : prefix(std::move(prefix)) {};
@@ -20,7 +52,7 @@ struct ParameterGroup {
     std::optional<std::size_t> prefixSearchPatternStart;
     std::optional<std::size_t> prefixSearchPatternEnd;
 
-    std::vector<ROSParameter> parameters;
+    std::vector<TreeElement> parameters;
     std::vector<std::shared_ptr<ParameterGroup>> subgroups;
 };
 
@@ -31,15 +63,15 @@ class ParameterTree {
     void add(const ROSParameter &parameter);
     void clear();
     std::shared_ptr<ParameterGroup> getRoot();
-    std::size_t getMaxParamNameLength() const;
+    [[nodiscard]] std::size_t getMaxParamNameLength() const;
 
-    ParameterTree filter(const std::string &filterString) const;
+    [[nodiscard]] ParameterTree filter(const std::string &filterString) const;
 
     void removeEmptySubgroups();
 
 
   private:
-    void add(const std::shared_ptr<ParameterGroup>& curNode, const ROSParameter& parameter);
+    void add(const std::shared_ptr<ParameterGroup> &curNode, const TreeElement &parameter);
 
     void filter(const std::shared_ptr<ParameterGroup> &destinationNode,
                 const std::shared_ptr<ParameterGroup> &sourceNode,

--- a/include/ros_parameter.hpp
+++ b/include/ros_parameter.hpp
@@ -11,7 +11,6 @@
 
 #include <string>
 #include <variant>
-#include <optional>
 
 // TODO: add arrays
 using ROSParameterVariant = std::variant<bool, int, double, std::string>;

--- a/include/ros_parameter.hpp
+++ b/include/ros_parameter.hpp
@@ -13,20 +13,15 @@
 #include <variant>
 #include <optional>
 
+// TODO: add arrays
+using ROSParameterVariant = std::variant<bool, int, double, std::string>;
+
 struct ROSParameter {
-    ROSParameter(std::string name, std::variant<bool, int, double, std::string> value,
-                 std::optional<std::size_t> searchPatternStart = std::nullopt,
-                 std::optional<std::size_t> searchPatternEnd = std::nullopt) : name(std::move(name)), value(std::move(value)),
-        searchPatternStart(searchPatternStart), searchPatternEnd(searchPatternEnd) {};
+    ROSParameter(std::string name, ROSParameterVariant value) :
+        name(std::move(name)), value(std::move(value)) {};
 
     std::string name;
-    // TODO: add arrays
-    std::variant<bool, int, double, std::string> value;
-
-    // in case this parameter is part of a filtered parameter tree the following two members store the intermediate
-    // information where in the name the applied search pattern is located
-    std::optional<std::size_t> searchPatternStart;
-    std::optional<std::size_t> searchPatternEnd;
+    ROSParameterVariant value;
 };
 
 #endif // RIG_RECONFIGURE_ROS_PARAMETER_HPP

--- a/src/parameter_tree.cpp
+++ b/src/parameter_tree.cpp
@@ -11,6 +11,8 @@
 #include <algorithm>
 #include <cstring>
 
+constexpr auto SEPARATORS = "/.\\";
+
 // declaration of utility functions
 bool recursivelyRemoveEmptySubgroups(const std::shared_ptr<ParameterGroup> &curNode);
 std::size_t findCaseInsensitive(const std::string &string, const std::string &pattern);
@@ -20,14 +22,14 @@ ParameterTree::ParameterTree() : root(std::make_shared<ParameterGroup>()) {
 }
 
 void ParameterTree::add(const ROSParameter &parameter) {
-    add(root, parameter);
+    add(root, TreeElement(parameter, parameter.name));
 }
 void ParameterTree::clear() {
     root = std::make_shared<ParameterGroup>();
 }
 
-void ParameterTree::add(const std::shared_ptr<ParameterGroup> &curNode, const ROSParameter &parameter) {
-    auto prefixStart = parameter.name.find('/');
+void ParameterTree::add(const std::shared_ptr<ParameterGroup> &curNode, const TreeElement &parameter) {
+    auto prefixStart = parameter.name.find_first_of(SEPARATORS);
     if (prefixStart == std::string::npos) {
         curNode->parameters.emplace_back(parameter);
         maxParamNameLength = std::max(maxParamNameLength, parameter.name.length());
@@ -51,7 +53,7 @@ void ParameterTree::add(const std::shared_ptr<ParameterGroup> &curNode, const RO
         curNode->subgroups.emplace_back(nextNode);
     }
 
-    add(nextNode, ROSParameter(remainingName, parameter.value));
+    add(nextNode, TreeElement(remainingName, parameter.fullPath, parameter.value));
 }
 
 std::shared_ptr<ParameterGroup> ParameterTree::getRoot() {

--- a/src/rig_reconfigure.cpp
+++ b/src/rig_reconfigure.cpp
@@ -39,7 +39,7 @@ static void glfw_error_callback(int error, const char *description) {
 static std::set<ImGuiID> visualizeParameters(ServiceWrapper &serviceWrapper,
                                              const std::shared_ptr<ParameterGroup> &parameterNode,
                                              std::size_t maxParamLength, const std::string &filterString,
-                                             bool expandAll = false, const std::string &prefix = "");
+                                             bool expandAll = false);
 static void highlightedText(const std::string &text, std::size_t start, std::size_t end,
                             const ImVec4 &highlightColor = FILTER_HIGHLIGHTING_COLOR);
 static bool highlightedSelectableText(const std::string &text, std::size_t start, std::size_t end,
@@ -431,7 +431,7 @@ int main(int argc, char *argv[]) {
 std::set<ImGuiID> visualizeParameters(ServiceWrapper &serviceWrapper,
                                          const std::shared_ptr<ParameterGroup> &parameterNode,
                                          std::size_t maxParamLength, const std::string &filterString,
-                                         const bool expandAll, const std::string &prefix) {
+                                         const bool expandAll) {
     std::set<ImGuiID> nodeIDs;
     auto *window = ImGui::GetCurrentWindow();
 
@@ -468,27 +468,27 @@ std::set<ImGuiID> visualizeParameters(ServiceWrapper &serviceWrapper,
 
         ImGui::SameLine();
         ImGui::PushItemWidth(INPUT_TEXT_FIELD_WIDTH);
-        std::string prefixWithName = prefix + '/' + name;
+
         if (std::holds_alternative<double>(value)) {
             if (ImGui::DragScalar(identifier.c_str(), ImGuiDataType_Double, &std::get<double>(value), 1.0F, nullptr,
                                   nullptr, "%.6g")) {
                 serviceWrapper.pushRequest(
-                        std::make_shared<ParameterModificationRequest>(ROSParameter(prefixWithName, value)));
+                        std::make_shared<ParameterModificationRequest>(ROSParameter(fullPath, value)));
             }
         } else if (std::holds_alternative<bool>(value)) {
             if (ImGui::Checkbox(identifier.c_str(), &std::get<bool>(value))) {
                 serviceWrapper.pushRequest(
-                        std::make_shared<ParameterModificationRequest>(ROSParameter(prefixWithName, value)));
+                        std::make_shared<ParameterModificationRequest>(ROSParameter(fullPath, value)));
             }
         } else if (std::holds_alternative<int>(value)) {
             if (ImGui::DragInt(identifier.c_str(), &std::get<int>(value))) {
                 serviceWrapper.pushRequest(
-                        std::make_shared<ParameterModificationRequest>(ROSParameter(prefixWithName, value)));
+                        std::make_shared<ParameterModificationRequest>(ROSParameter(fullPath, value)));
             }
         } else if (std::holds_alternative<std::string>(value)) {
             if (ImGui::InputText(identifier.c_str(), &std::get<std::string>(value))) {
                 serviceWrapper.pushRequest(
-                        std::make_shared<ParameterModificationRequest>(ROSParameter(prefixWithName, value)));
+                        std::make_shared<ParameterModificationRequest>(ROSParameter(fullPath, value)));
             }
         }
         ImGui::PopItemWidth();
@@ -523,7 +523,7 @@ std::set<ImGuiID> visualizeParameters(ServiceWrapper &serviceWrapper,
 
             if (open) {
                 auto subIDs = visualizeParameters(serviceWrapper, subgroup, maxParamLength, filterString,
-                                                  expandAll, prefix + '/' + subgroup->prefix);
+                                                  expandAll);
                 nodeIDs.insert(subIDs.begin(), subIDs.end());
                 ImGui::TreePop();
             }

--- a/src/rig_reconfigure.cpp
+++ b/src/rig_reconfigure.cpp
@@ -445,7 +445,7 @@ std::set<ImGuiID> visualizeParameters(ServiceWrapper &serviceWrapper,
         return {};
     }
 
-    for (auto &[name, value, highlightingStart, highlightingEnd] : parameterNode->parameters) {
+    for (auto &[name, fullPath, value, highlightingStart, highlightingEnd] : parameterNode->parameters) {
         std::string identifier = "##" + name;
 
         // simple 'space' padding to avoid the need for a more complex layout with columns (the latter is still desired


### PR DESCRIPTION
In the past we have only been accepting `/` as a separator, which was sufficient for our own parameter handling. However, others may e.g. use ROS yaml files for storing their parameters, which default to `.` as separator.

With this MR, the GUI now accepts `/`, `.` and `\` as separating characters. If others are needed, they can be easily added.