### PR TITLE
Persist window size via .ini file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ add_executable(${PROJECT_NAME} src/rig_reconfigure.cpp src/service_wrapper.cpp s
 #target_compile_options(${PROJECT_NAME} PRIVATE -g -fsanitize=thread)
 #target_link_options(${PROJECT_NAME} PRIVATE -fsanitize=thread)
 
-target_include_directories(${PROJECT_NAME} PRIVATE include external/imspinner external/lodepng)
+target_include_directories(${PROJECT_NAME} PRIVATE include external/lodepng)
 target_link_libraries(${PROJECT_NAME} imgui rclcpp::rclcpp ament_index_cpp::ament_index_cpp)
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/node_window.cpp
+++ b/src/node_window.cpp
@@ -19,7 +19,7 @@ struct TreeNode {
     std::string name; // node name (leaf node) / namespace (other)
     std::string fullName; // full node name for easier usage
 
-    std::vector<std::shared_ptr<TreeNode>> children;
+    std::vector<std::shared_ptr<TreeNode>> children = {};
 };
 
 class NodeTree {

--- a/src/rig_reconfigure.cpp
+++ b/src/rig_reconfigure.cpp
@@ -74,7 +74,7 @@ int main(int argc, char *argv[]) {
         std::filesystem::create_directory(config_file_dir);
     }
 
-    ImGui::GetIO().IniFilename = config_file_path.c_str();
+    ImGui::GetIO().IniFilename = config_file_path.c_str(); // important for automatic saving of .ini file
     ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_DockingEnable;
 
     // load window size if already stored from last iteration
@@ -83,12 +83,15 @@ int main(int argc, char *argv[]) {
     auto window_height = DEFAULT_WINDOW_HEIGHT;
 
     if (configFileExisting) {
+        // manual loading of the .ini file since we require the window size before creating the glfw window
         ImGui::LoadIniSettingsFromDisk(config_file_path.c_str());
         ImGuiID id = ImHashStr("Root window");
         ImGuiWindowSettings* root_window_settings = ImGui::FindWindowSettingsByID(id);
 
-        window_width = root_window_settings->Size.x;
-        window_height = root_window_settings->Size.y;
+        if (root_window_settings != nullptr) {
+            window_width = root_window_settings->Size.x;
+            window_height = root_window_settings->Size.y;
+        }
     }
 
     // Create window with graphics context


### PR DESCRIPTION
Fixes the bug that the root window was always created with the default size (thereby ignoring the potentially different size stored in the .ini file).

This MR additionally includes minor refactoring (warnings, cleanup of CMakeLists.txt, ...)