### PR TITLE
Add support for parameter ranges and disabling readonly parameters.

### DIFF
--- a/include/parameter_tree.hpp
+++ b/include/parameter_tree.hpp
@@ -12,6 +12,9 @@
 #include <memory>
 #include <optional>
 #include <utility>
+
+#include <rcl_interfaces/msg/parameter_descriptor.hpp>
+
 #include "responses.hpp"
 
 /**
@@ -22,16 +25,19 @@ struct TreeElement {
     TreeElement(const ROSParameter &parameter_, std::string fullParameterPath_,
                 std::optional<std::size_t> patternStart_ = std::nullopt,
                 std::optional<std::size_t> patternEnd_ = std::nullopt) :
-        name(parameter_.name), fullPath(std::move(fullParameterPath_)), value(parameter_.value),
+        name(parameter_.name), description(parameter_.description), 
+        fullPath(std::move(fullParameterPath_)), value(parameter_.value),
         searchPatternStart(patternStart_), searchPatternEnd(patternEnd_) {};
 
-    TreeElement(std::string name_, std::string fullParameterPath_, ROSParameterVariant value_,
+    TreeElement(std::string name_, const rcl_interfaces::msg::ParameterDescriptor &description_, 
+                std::string fullParameterPath_, ROSParameterVariant value_,
                 std::optional<std::size_t> patternStart_ = std::nullopt,
                 std::optional<std::size_t> patternEnd_ = std::nullopt) :
-        name(std::move(name_)), fullPath(std::move(fullParameterPath_)), value(std::move(value_)),
-        searchPatternStart(patternStart_), searchPatternEnd(patternEnd_) {};
+        name(std::move(name_)), description(description_), fullPath(std::move(fullParameterPath_)),
+        value(std::move(value_)), searchPatternStart(patternStart_), searchPatternEnd(patternEnd_) {};
 
     std::string name; // parameter name without prefixes
+    rcl_interfaces::msg::ParameterDescriptor description;
 
     // in addition to the name we store the full path of the parameter in the leaf nodes of the tree in order to be
     // able to support the mixing of different separators

--- a/include/requests.hpp
+++ b/include/requests.hpp
@@ -12,11 +12,15 @@
 #include <utility>
 #include <vector>
 #include <string>
+
+#include <rcl_interfaces/msg/parameter_descriptor.hpp>
+
 #include "ros_parameter.hpp"
 
 struct Request {
     enum class Type {
-        TERMINATE, QUERY_NODE_NAMES, QUERY_NODE_PARAMETERS, QUERY_PARAMETER_VALUES, MODIFY_PARAMETER_VALUE
+        TERMINATE, QUERY_NODE_NAMES, QUERY_NODE_PARAMETERS, QUERY_PARAMETER_DESCRIPTIONS, 
+        QUERY_PARAMETER_VALUES, MODIFY_PARAMETER_VALUE
     };
 
     explicit Request(Type type_) : type(type_) {};
@@ -28,7 +32,18 @@ struct Request {
 using RequestPtr = std::shared_ptr<Request>;
 
 struct ParameterValueRequest : Request {
-    explicit ParameterValueRequest(const std::vector<std::string> &parameterNames_) : Request(Type::QUERY_PARAMETER_VALUES), parameterNames(parameterNames_) {};
+    explicit ParameterValueRequest(
+        const std::vector<std::string> &parameterNames_, 
+        const std::vector<rcl_interfaces::msg::ParameterDescriptor> &parameterDescriptors_) 
+            : Request(Type::QUERY_PARAMETER_VALUES), parameterNames(parameterNames_),
+              parameterDescriptors(parameterDescriptors_) {};
+
+    std::vector<std::string> parameterNames;
+    std::vector<rcl_interfaces::msg::ParameterDescriptor> parameterDescriptors;
+};
+
+struct ParameterDescriptionRequest : Request {
+    explicit ParameterDescriptionRequest(const std::vector<std::string> &parameterNames_) : Request(Type::QUERY_PARAMETER_DESCRIPTIONS), parameterNames(parameterNames_) {};
 
     std::vector<std::string> parameterNames;
 };

--- a/include/ros_parameter.hpp
+++ b/include/ros_parameter.hpp
@@ -12,6 +12,8 @@
 #include <string>
 #include <variant>
 
+#include <rcl_interfaces/msg/parameter_descriptor.hpp>
+
 // TODO: add arrays
 using ROSParameterVariant = std::variant<bool, int, double, std::string>;
 
@@ -19,6 +21,11 @@ struct ROSParameter {
     ROSParameter(std::string name_, ROSParameterVariant value_) :
         name(std::move(name_)), value(std::move(value_)) {};
 
+    ROSParameter(rcl_interfaces::msg::ParameterDescriptor description_, ROSParameterVariant value_) :
+        description(std::move(description_)), name(description.name), value(std::move(value_)) {};
+
+
+    rcl_interfaces::msg::ParameterDescriptor description;
     std::string name;
     ROSParameterVariant value;
 };

--- a/include/service_wrapper.hpp
+++ b/include/service_wrapper.hpp
@@ -78,14 +78,17 @@ class ServiceWrapper {
 
     // clients for calling the different services
     rclcpp::Client<rcl_interfaces::srv::ListParameters>::SharedPtr listParametersClient;
+    rclcpp::Client<rcl_interfaces::srv::DescribeParameters>::SharedPtr describeParametersClient;
     rclcpp::Client<rcl_interfaces::srv::GetParameters>::SharedPtr getParametersClient;
     rclcpp::Client<rcl_interfaces::srv::SetParameters>::SharedPtr setParametersClient;
 
     // callbacks for the results of the futures
     void nodeParametersReceived(const rclcpp::Client<rcl_interfaces::srv::ListParameters>::SharedFuture &future,
                                 const std::shared_ptr<FutureTimeoutContainer> &timeoutContainer);
+    void parameterDescriptionsReceived(const rclcpp::Client<rcl_interfaces::srv::DescribeParameters>::SharedFuture &future,
+                                       const std::shared_ptr<FutureTimeoutContainer> &timeoutContainer);
     void parameterValuesReceived(const rclcpp::Client<rcl_interfaces::srv::GetParameters>::SharedFuture &future,
-                                 const std::vector<std::string> &parameterNames,
+                                 const std::vector<rcl_interfaces::msg::ParameterDescriptor> &parameterDescriptors,
                                  const std::shared_ptr<FutureTimeoutContainer> &timeoutContainer);
     void parameterModificationResponseReceived(const rclcpp::Client<rcl_interfaces::srv::SetParameters>::SharedFuture &future,
                                                const std::string &parameterName,

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -14,6 +14,7 @@
 #include <filesystem>
 
 #include <GLFW/glfw3.h> // will drag system OpenGL headers
+#include <rcl_interfaces/msg/parameter_descriptor.hpp>
 
 struct Status {
     enum class Type { NONE, NO_NODES_AVAILABLE, PARAMETER_CHANGED, SERVICE_TIMEOUT };
@@ -43,6 +44,59 @@ void highlightedText(const std::string &text, std::size_t start, std::size_t end
  */
 bool highlightedSelectableText(const std::string &text, std::size_t start, std::size_t end,
                                const ImVec4 &highlightColor);
+
+std::string getFormatStringFromStep(double step, int max_digits = 10);
+
+/**
+ * Checks if a given parameter has a range that is effectively bounded on both sides.
+ *
+ * @param param Parameter description.
+ */
+bool hasBoundedRange(const rcl_interfaces::msg::ParameterDescriptor& param);
+
+/**
+ * Checks if two double values are equal to within a specified tolerance.
+ *
+ * @param x   First value.
+ * @param y   Second value.
+ * @param ulp Maximum number of representable numbers between x and y.
+ */
+bool areDoublesEqual(double x, double y, double ulp = 100.0);
+
+/**
+ * Snaps and clamps a double value to a given range and step.
+ *
+ * Note: The value is snapped to the nearest integer number of steps from the 'from_value'
+ *       or clamped to the 'to_value'.
+ *
+ *       The magnitude of the 'step' is used and the sign is ignored.
+ *
+ *       If 'step' == 0 or if 'from_value' is == double::lowest(), the range is considered
+ *       continuous.
+ *
+ * @param value      Input value.
+ * @param from_value Range minimum.
+ * @param to_value   Range maximum.
+ * @param step       Step size.
+ */
+double snapToDoubleRange(double value, double from_value, double to_value, double step);
+
+/**
+ * Snaps and clamps an integer value to a given range and step.
+ *
+ * Note: The value is snapped to the nearest integer number of steps from the 'from_value'
+ *       or clamped to the 'to_value'.
+ *
+ *       The magnitude of 'step' is used and the sign is ignored.
+ *
+ *       If 'step' == 0, the step size is considered 1.
+ *
+ * @param value      Input value.
+ * @param from_value Range minimum.
+ * @param to_value   Range maximum.
+ * @param step       Step size.
+ */
+int64_t snapToIntegerRange(int64_t value, int64_t from_value, int64_t to_value, uint64_t step);
 
 /**
  * Searches for the resource directory.

--- a/src/parameter_tree.cpp
+++ b/src/parameter_tree.cpp
@@ -53,7 +53,8 @@ void ParameterTree::add(const std::shared_ptr<ParameterGroup> &curNode, const Tr
         curNode->subgroups.emplace_back(nextNode);
     }
 
-    add(nextNode, TreeElement(remainingName, parameter.fullPath, parameter.value));
+    add(nextNode, TreeElement(remainingName, parameter.description, parameter.fullPath, 
+                              parameter.value));
 }
 
 std::shared_ptr<ParameterGroup> ParameterTree::getRoot() {

--- a/src/parameter_window.cpp
+++ b/src/parameter_window.cpp
@@ -107,6 +107,9 @@ void renderParameterWindow(const char *windowName, const std::string &curSelecte
 }
 
 std::string getFormatStringFromStep(double step, int max_digits = 10) {
+    if (step == 0) {
+        return std::string("%.6g");
+    }
     const double epsilon = 1e-12;  // tolerance for rounding error
     int digits = 0;
     double scaled = step;
@@ -115,6 +118,96 @@ std::string getFormatStringFromStep(double step, int max_digits = 10) {
         ++digits;
     }
     return "%." + std::to_string(digits) + "f";
+}
+
+bool hasBoundedRange(const rcl_interfaces::msg::ParameterDescriptor& param) {
+    if (param.type == rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE) {
+        if (param.floating_point_range.empty()) {
+            return false;
+        }
+
+        if (!std::isfinite(param.floating_point_range[0].from_value) ||
+            !std::isfinite(param.floating_point_range[0].to_value)) {
+            return false;
+        }
+
+        if (param.floating_point_range[0].from_value <= -std::numeric_limits<float>::max() ||
+            param.floating_point_range[0].from_value >=  std::numeric_limits<float>::max()) {
+            return false;
+        }
+
+        if (param.floating_point_range[0].to_value <= -std::numeric_limits<float>::max() ||
+            param.floating_point_range[0].to_value >=  std::numeric_limits<float>::max()) {
+            return false;
+        }
+
+        return true;
+    }
+    else if (param.type == rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER) {
+        if (param.integer_range.empty()) {
+            return false;
+        }
+
+        return true;
+    }
+    return false;
+}
+
+bool areDoublesEqual(double x, double y, double ulp = 100.0) {
+  return std::abs(x - y) <= std::numeric_limits<double>::epsilon() * std::abs(x + y) * ulp;
+}
+
+double snapToDoubleRange(double value, double from_value, double to_value, double step) {
+    // this mostly matches the logic for checking if a double parameter value is 
+    // valid for a defined floating point range: rclcpp/node_interfaces/node_parameters.cpp
+
+    // clamp value within bounds
+    value = std::clamp(value, from_value, to_value);
+
+    // handle cases where the step is not defined or would be invalid
+    if (step == 0.0 || std::isnan(step) || from_value == std::numeric_limits<double>::lowest()) {
+        // continuous range
+        return value;
+    }
+
+    // return from_value if the value is within 100 ULPs
+    if (areDoublesEqual(value, from_value)) {
+        return from_value;
+    }
+
+    // return to_value if the value is within 100 ULPs
+    if (areDoublesEqual(value, to_value)) {
+        return to_value;
+    }
+
+    // snap to closest step
+    step = std::abs(step);
+    return from_value + std::round((value - from_value) / step) * step;
+}
+
+int64_t snapToIntegerRange(int64_t value, int64_t from_value, int64_t to_value, uint64_t step) {
+    // this mostly matches the logic for checking if a double parameter value is 
+    // valid for a defined integer range: rclcpp/node_interfaces/node_parameters.cpp
+
+    value = std::clamp(value, from_value, to_value);
+
+    if (step == 0 || step == 1) {
+        // all integers within range
+        return value;
+    }
+
+    // the start of the range is always valid
+    if (value == from_value) {
+        return value;
+    }
+
+    // the end of the range is always valid
+    if (value == to_value) {
+        return value;
+    }
+
+    // snap to closest step
+    return from_value + static_cast<int64_t>(std::round((value - from_value) / static_cast<double>(step))) * step;
 }
 
 std::set<ImGuiID> visualizeParameters(ServiceWrapper &serviceWrapper,
@@ -169,18 +262,29 @@ std::set<ImGuiID> visualizeParameters(ServiceWrapper &serviceWrapper,
         }
 
         if (std::holds_alternative<double>(value)) {
-            if (!descriptor.floating_point_range.empty()) {
+            if (hasBoundedRange(descriptor)) {
                 double* min = &descriptor.floating_point_range[0].from_value;
                 double* max = &descriptor.floating_point_range[0].to_value;
                 double step = std::fabs(descriptor.floating_point_range[0].step);
-                std::string format = "%.6g";
-                if (step != 0) {
-                    format = getFormatStringFromStep(step);
-                }
+                std::string format = getFormatStringFromStep(step);
                 if(ImGui::SliderScalar(identifier.c_str(), ImGuiDataType_Double, 
                                     &std::get<double>(value), min, max, format.c_str(), 
-                                    ImGuiSliderFlags_AlwaysClamp) && step != 0) {
-                    std::get<double>(value) = std::round((std::get<double>(value) - *min) / step) * step + *min;
+                                    ImGuiSliderFlags_AlwaysClamp)) {
+                    std::get<double>(value) = snapToDoubleRange(std::get<double>(value), *min, *max, step);
+                }
+            }
+            else if (!descriptor.floating_point_range.empty()) {
+                double* min = &descriptor.floating_point_range[0].from_value;
+                double* max = &descriptor.floating_point_range[0].to_value;
+                double step = std::fabs(descriptor.floating_point_range[0].step);
+                std::string format = getFormatStringFromStep(step);
+                double speed = 1.0;
+                if (step != 0.0 && !std::isnan(step)) {
+                    speed = step;
+                }
+                if(ImGui::DragScalar(identifier.c_str(), ImGuiDataType_Double, &std::get<double>(value), 
+                                     speed, min, max, format.c_str())) {
+                    std::get<double>(value) = snapToDoubleRange(std::get<double>(value), *min, *max, step);
                 }
             }
             else {
@@ -197,13 +301,13 @@ std::set<ImGuiID> visualizeParameters(ServiceWrapper &serviceWrapper,
                         std::make_shared<ParameterModificationRequest>(ROSParameter(fullPath, value)));
             }
         } else if (std::holds_alternative<int>(value)) {
-            if (!descriptor.integer_range.empty()) {
+            if (hasBoundedRange(descriptor)) {
                 int min = descriptor.integer_range[0].from_value;
                 int max = descriptor.integer_range[0].to_value;
                 int step = descriptor.integer_range[0].step;
 
                 if(ImGui::SliderInt(identifier.c_str(), &std::get<int>(value), min, max) && step != 0) {
-                    std::get<int>(value) = static_cast<int>(std::round((std::get<int>(value) - min) / step) * step + min);
+                    std::get<int>(value) = snapToIntegerRange(std::get<int>(value), min, max, step);
                 }
             }
             else {

--- a/src/parameter_window.cpp
+++ b/src/parameter_window.cpp
@@ -178,7 +178,7 @@ std::set<ImGuiID> visualizeParameters(ServiceWrapper &serviceWrapper,
                     speed = step;
                 }
                 if(ImGui::DragScalar(identifier.c_str(), ImGuiDataType_Double, &std::get<double>(value), 
-                                     speed, min, max, format.c_str())) {
+                                     speed, min, max, format.c_str(), ImGuiSliderFlags_AlwaysClamp)) {
                     std::get<double>(value) = snapToDoubleRange(std::get<double>(value), *min, *max, step);
                 }
             }
@@ -201,7 +201,8 @@ std::set<ImGuiID> visualizeParameters(ServiceWrapper &serviceWrapper,
                 int max = descriptor.integer_range[0].to_value;
                 int step = descriptor.integer_range[0].step;
 
-                if(ImGui::SliderInt(identifier.c_str(), &std::get<int>(value), min, max) && step != 0) {
+                if(ImGui::SliderInt(identifier.c_str(), &std::get<int>(value), min, max, "%d",
+                                    ImGuiSliderFlags_AlwaysClamp)) {
                     std::get<int>(value) = snapToIntegerRange(std::get<int>(value), min, max, step);
                 }
             }

--- a/src/parameter_window.cpp
+++ b/src/parameter_window.cpp
@@ -49,8 +49,6 @@ void renderParameterWindow(const char *windowName, const std::string &curSelecte
 
     bool expandAllParameters = false;
 
-    const auto curWindowWidth = static_cast<int>(ImGui::GetWindowSize().x);
-
     if (!curSelectedNode.empty()) {
         ImGui::Text("Parameters of '%s'", curSelectedNode.c_str());
         ImGui::Dummy(ImVec2(0.0F, 5.0F));
@@ -106,109 +104,6 @@ void renderParameterWindow(const char *windowName, const std::string &curSelecte
     ImGui::End();
 }
 
-std::string getFormatStringFromStep(double step, int max_digits = 10) {
-    if (step == 0) {
-        return std::string("%.6g");
-    }
-    const double epsilon = 1e-12;  // tolerance for rounding error
-    int digits = 0;
-    double scaled = step;
-    while (digits < max_digits && std::abs(scaled - std::round(scaled)) > epsilon) {
-        scaled *= 10.0;
-        ++digits;
-    }
-    return "%." + std::to_string(digits) + "f";
-}
-
-bool hasBoundedRange(const rcl_interfaces::msg::ParameterDescriptor& param) {
-    if (param.type == rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE) {
-        if (param.floating_point_range.empty()) {
-            return false;
-        }
-
-        if (!std::isfinite(param.floating_point_range[0].from_value) ||
-            !std::isfinite(param.floating_point_range[0].to_value)) {
-            return false;
-        }
-
-        if (param.floating_point_range[0].from_value <= -std::numeric_limits<float>::max() ||
-            param.floating_point_range[0].from_value >=  std::numeric_limits<float>::max()) {
-            return false;
-        }
-
-        if (param.floating_point_range[0].to_value <= -std::numeric_limits<float>::max() ||
-            param.floating_point_range[0].to_value >=  std::numeric_limits<float>::max()) {
-            return false;
-        }
-
-        return true;
-    }
-    else if (param.type == rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER) {
-        if (param.integer_range.empty()) {
-            return false;
-        }
-
-        return true;
-    }
-    return false;
-}
-
-bool areDoublesEqual(double x, double y, double ulp = 100.0) {
-  return std::abs(x - y) <= std::numeric_limits<double>::epsilon() * std::abs(x + y) * ulp;
-}
-
-double snapToDoubleRange(double value, double from_value, double to_value, double step) {
-    // this mostly matches the logic for checking if a double parameter value is 
-    // valid for a defined floating point range: rclcpp/node_interfaces/node_parameters.cpp
-
-    // clamp value within bounds
-    value = std::clamp(value, from_value, to_value);
-
-    // handle cases where the step is not defined or would be invalid
-    if (step == 0.0 || std::isnan(step) || from_value == std::numeric_limits<double>::lowest()) {
-        // continuous range
-        return value;
-    }
-
-    // return from_value if the value is within 100 ULPs
-    if (areDoublesEqual(value, from_value)) {
-        return from_value;
-    }
-
-    // return to_value if the value is within 100 ULPs
-    if (areDoublesEqual(value, to_value)) {
-        return to_value;
-    }
-
-    // snap to closest step
-    step = std::abs(step);
-    return from_value + std::round((value - from_value) / step) * step;
-}
-
-int64_t snapToIntegerRange(int64_t value, int64_t from_value, int64_t to_value, uint64_t step) {
-    // this mostly matches the logic for checking if a double parameter value is 
-    // valid for a defined integer range: rclcpp/node_interfaces/node_parameters.cpp
-
-    value = std::clamp(value, from_value, to_value);
-
-    if (step == 0 || step == 1) {
-        // all integers within range
-        return value;
-    }
-
-    // the start of the range is always valid
-    if (value == from_value) {
-        return value;
-    }
-
-    // the end of the range is always valid
-    if (value == to_value) {
-        return value;
-    }
-
-    // snap to closest step
-    return from_value + static_cast<int64_t>(std::round((value - from_value) / static_cast<double>(step))) * step;
-}
 
 std::set<ImGuiID> visualizeParameters(ServiceWrapper &serviceWrapper,
                                       const std::shared_ptr<ParameterGroup> &parameterNode,

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -10,7 +10,10 @@
 
 #include <ament_index_cpp/get_package_prefix.hpp>
 #include <ament_index_cpp/get_package_share_directory.hpp>
+#include <rcl_interfaces/msg/parameter_type.hpp>
+#include <cmath>
 #include <iostream>
+#include <limits>
 #include <vector>
 
 #include "lodepng.h"
@@ -60,6 +63,110 @@ bool highlightedSelectableText(const std::string &text, std::size_t start, std::
     }
 
     return selected;
+}
+
+std::string getFormatStringFromStep(double step, int max_digits) {
+    if (step == 0) {
+        return std::string("%.6g");
+    }
+    const double epsilon = 1e-12;  // tolerance for rounding error
+    int digits = 0;
+    double scaled = step;
+    while (digits < max_digits && std::abs(scaled - std::round(scaled)) > epsilon) {
+        scaled *= 10.0;
+        ++digits;
+    }
+    return "%." + std::to_string(digits) + "f";
+}
+
+bool hasBoundedRange(const rcl_interfaces::msg::ParameterDescriptor& param) {
+    if (param.type == rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE) {
+        if (param.floating_point_range.empty()) {
+            return false;
+        }
+
+        if (!std::isfinite(param.floating_point_range[0].from_value) ||
+            !std::isfinite(param.floating_point_range[0].to_value)) {
+            return false;
+        }
+
+        if (param.floating_point_range[0].from_value <= -std::numeric_limits<float>::max() ||
+            param.floating_point_range[0].from_value >=  std::numeric_limits<float>::max()) {
+            return false;
+        }
+
+        if (param.floating_point_range[0].to_value <= -std::numeric_limits<float>::max() ||
+            param.floating_point_range[0].to_value >=  std::numeric_limits<float>::max()) {
+            return false;
+        }
+
+        return true;
+    }
+    else if (param.type == rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER) {
+        if (param.integer_range.empty()) {
+            return false;
+        }
+
+        return true;
+    }
+    return false;
+}
+
+bool areDoublesEqual(double x, double y, double ulp) {
+  return std::abs(x - y) <= std::numeric_limits<double>::epsilon() * std::abs(x + y) * ulp;
+}
+
+double snapToDoubleRange(double value, double from_value, double to_value, double step) {
+    // this mostly matches the logic for checking if a double parameter value is
+    // valid for a defined floating point range: rclcpp/node_interfaces/node_parameters.cpp
+
+    // clamp value within bounds
+    value = std::clamp(value, from_value, to_value);
+
+    // handle cases where the step is not defined or would be invalid
+    if (step == 0.0 || std::isnan(step) || from_value == std::numeric_limits<double>::lowest()) {
+        // continuous range
+        return value;
+    }
+
+    // return from_value if the value is within 100 ULPs
+    if (areDoublesEqual(value, from_value)) {
+        return from_value;
+    }
+
+    // return to_value if the value is within 100 ULPs
+    if (areDoublesEqual(value, to_value)) {
+        return to_value;
+    }
+
+    // snap to closest step
+    step = std::abs(step);
+    return from_value + std::round((value - from_value) / step) * step;
+}
+
+int64_t snapToIntegerRange(int64_t value, int64_t from_value, int64_t to_value, uint64_t step) {
+    // this mostly matches the logic for checking if a double parameter value is
+    // valid for a defined integer range: rclcpp/node_interfaces/node_parameters.cpp
+
+    value = std::clamp(value, from_value, to_value);
+
+    if (step == 0 || step == 1) {
+        // all integers within range
+        return value;
+    }
+
+    // the start of the range is always valid
+    if (value == from_value) {
+        return value;
+    }
+
+    // the end of the range is always valid
+    if (value == to_value) {
+        return value;
+    }
+
+    // snap to closest step
+    return from_value + static_cast<int64_t>(std::round((value - from_value) / static_cast<double>(step))) * step;
 }
 
 std::filesystem::path findResourcePath(const std::string &execPath) {


### PR DESCRIPTION
In ROS2 it's possible to define parameter constraints min, max, and step size as well as if a parameter is read only or not.

This PR updates the tool to query for the parameter descriptions using the "describe_parameters" service (https://docs.ros2.org/foxy/api/rcl_interfaces/srv/DescribeParameters.html) and use the description to constrain the input widgets.

If a range is defined for either int or float parameters, a slider input with the range is used instead of a drag.  If a non-zero step size is defined, then the slider will snap to the nearest valid value, which is in the form: min + N x step.

It's important to honor the range and step constraints because any requests to set values outside the constraints are rejected by ROS.

Any read-only parameters are disabled so it's clear to the user that they can't be modified.

Before:
![before](https://github.com/user-attachments/assets/53d5437d-a4ed-48ea-9b1f-c8becf36a13a)

After:
![after2](https://github.com/user-attachments/assets/4b423fb6-3e44-40c2-8dbe-a7191f8c0d84)
