### PR TITLE
fix errors when exiting rig via sigint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_CXX_STANDARD 20)
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(backward_ros REQUIRED)
 
 # Download imgui
 include(FetchContent)

--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
     <depend>libglfw3-dev</depend>
     <depend>rclcpp</depend>
     <depend>ament_index_cpp</depend>
+    <depend>backward_ros</depend>
 
     <export>
         <build_type>ament_cmake</build_type>

--- a/src/rig_reconfigure.cpp
+++ b/src/rig_reconfigure.cpp
@@ -134,7 +134,7 @@ int main(int argc, char *argv[]) {
     serviceWrapper.setIgnoreDefaultParameters(ignoreDefaultParameters);
 
     // Main loop
-    while (!glfwWindowShouldClose(window)) {
+    while (!glfwWindowShouldClose(window) && rclcpp::ok()) {
         // these variables are only relevant for a single iteration
         const auto frame_start = std::chrono::high_resolution_clock::now();
 

--- a/src/service_wrapper.cpp
+++ b/src/service_wrapper.cpp
@@ -25,8 +25,9 @@ ServiceWrapper::ServiceWrapper(bool ignoreDefaultParameters_) : ignoreDefaultPar
 
     thread = std::thread(&ServiceWrapper::threadFunc, this);
     rosThread = std::thread([&]() {
+        auto future = terminationHelper.get_future();
         while (!terminateThread) {
-            executor.spin_until_future_complete(terminationHelper.get_future());
+            executor.spin_until_future_complete(future);
         }
     });
 }


### PR DESCRIPTION
before:
```
^C[INFO] [1744976434.675516879] [rclcpp]: signal_handler(signum=2)
terminate called after throwing an instance of 'std::future_error'
  what():  std::future_error: Future already retrieved
[ros2run]: Aborted
```
after:
```
^C[INFO] [1744976468.472134123] [rclcpp]: signal_handler(signum=2)
```