### PR TITLE
fix wrong bounds on one-sided numeric parameter bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The following features are not implemented yet, but would be nice to have. PRs a
 - feedback about the success of modifying parameters 
   (intended: directly behind the parameters, e.g. using spinners / checkmarks)
 - support for array parameters
-- consideration of limits specified in the [parameter description](https://docs.ros2.org/galactic/api/rcl_interfaces/msg/ParameterDescriptor.html)
+- support for one-sided value bounds specified in the [parameter description](https://docs.ros2.org/galactic/api/rcl_interfaces/msg/ParameterDescriptor.html)
 
 ## Known Issues
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -10,6 +10,7 @@
 
 #include <ament_index_cpp/get_package_prefix.hpp>
 #include <ament_index_cpp/get_package_share_directory.hpp>
+#include <cstdint>
 #include <rcl_interfaces/msg/parameter_type.hpp>
 #include <cmath>
 #include <iostream>
@@ -104,6 +105,12 @@ bool hasBoundedRange(const rcl_interfaces::msg::ParameterDescriptor& param) {
     }
     else if (param.type == rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER) {
         if (param.integer_range.empty()) {
+            return false;
+        }
+
+        // This is how generate_parameter_library encodes open integer ranges
+        if (param.integer_range.at(0).to_value == std::numeric_limits<int64_t>::max() ||
+            param.integer_range.at(0).from_value == std::numeric_limits<int64_t>::lowest()) {
             return false;
         }
 


### PR DESCRIPTION
Before, a parameter such as
```yaml
example_node:
  background:
    gt_neg_3:
      type: int
      default_value: 0
      validation:
        gt<>: -3
```
would be displayed as if it had bounds `[-3,-1]` for some reason. Now this is correctly detected as non-bounded range. Support for actually displaying one-sided bounds (have inf/max-int for one of the bounds) might be added in the future.